### PR TITLE
Add missing require statement to load under Zeitwerk

### DIFF
--- a/lib/factory_bot_factory/factories/model_factory.rb
+++ b/lib/factory_bot_factory/factories/model_factory.rb
@@ -1,3 +1,5 @@
+require 'factory_bot_factory/factories/base_factory'
+
 module FactoryBotFactory
   class ModelFactory < BaseFactory
     def build_factory(name, value, level, _options = {})


### PR DESCRIPTION
This single change fixes the loading issue with Zeitwerk.

I've run the tests under Ruby 3.1.4, and included it in a brand-new Rails 7.1.latest project, where I initially saw the error (app would not even load) and it is working again with this one change.